### PR TITLE
Add support to the catching and throwing of assertions

### DIFF
--- a/core/HaskellWorks/Prelude.hs
+++ b/core/HaskellWorks/Prelude.hs
@@ -108,6 +108,27 @@ module HaskellWorks.Prelude
 
   , for_
 
+  , Fractional(..)
+  , Real(..)
+  , RealFrac(..)
+  , Ratio(..)
+  , Rational
+  , fromIntegral
+  , realToFrac
+  , even
+  , odd
+  , numericEnumFrom
+  , numericEnumFromThen
+  , numericEnumFromTo
+  , numericEnumFromThenTo
+  , integralEnumFrom
+  , integralEnumFromThen
+  , integralEnumFromTo
+  , integralEnumFromThenTo
+  , numerator
+  , denominator
+  , (%)
+
   , Monad(..)
   , MonadFail(..)
   , MonadPlus(..)
@@ -161,6 +182,7 @@ import           Data.Word
 import           GHC.Base
 import           GHC.Generics
 import           GHC.Num
+import           GHC.Real
 import           GHC.Stack
 import           System.FilePath
 import           Text.Show

--- a/hedgehog/HaskellWorks/Polysemy/Hedgehog.hs
+++ b/hedgehog/HaskellWorks/Polysemy/Hedgehog.hs
@@ -24,6 +24,11 @@ module HaskellWorks.Polysemy.Hedgehog
     failMessage,
     (===),
 
+    byDeadlineIO,
+    byDeadlineM,
+    byDurationIO,
+    byDurationM,
+
     eval,
     evalM,
     evalIO,

--- a/hedgehog/HaskellWorks/Polysemy/Hedgehog.hs
+++ b/hedgehog/HaskellWorks/Polysemy/Hedgehog.hs
@@ -33,6 +33,10 @@ module HaskellWorks.Polysemy.Hedgehog
     evalIO_,
     evalM_,
 
+    catchAssertion,
+    throwAssertion,
+    trapAssertion,
+
     jotShow,
     jotShow_,
     jotJson,

--- a/hedgehog/HaskellWorks/Polysemy/Hedgehog/Effect/Hedgehog/Internal.hs
+++ b/hedgehog/HaskellWorks/Polysemy/Hedgehog/Effect/Hedgehog/Internal.hs
@@ -1,11 +1,20 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
 module HaskellWorks.Polysemy.Hedgehog.Effect.Hedgehog.Internal
-  ( failWithCustom
+  ( MonadAssertion(..)
+  , failWithCustom
   ) where
 
 import           HaskellWorks.Polysemy.Prelude
 import qualified Hedgehog                      as H
 import qualified Hedgehog.Internal.Property    as H
 import qualified Hedgehog.Internal.Source      as H
+
+import qualified Control.Monad.Trans.Except as E
+import qualified Control.Monad.Trans.Resource as IO
+import qualified Control.Monad.Trans.Resource.Internal as IO
+import           Control.Monad.Trans.Class
 
 failWithCustom :: ()
   => H.MonadTest m
@@ -15,3 +24,16 @@ failWithCustom :: ()
   -> m a
 failWithCustom cs mdiff msg =
   H.liftTest $ H.mkTest (Left $ H.Failure (H.getCaller cs) msg mdiff, mempty)
+class Monad m => MonadAssertion m where
+  throwAssertion :: H.Failure -> m a
+  catchAssertion :: m a -> (H.Failure -> m a) -> m a
+
+instance Monad m => MonadAssertion (H.TestT m) where
+  throwAssertion f = H.liftTest $ H.mkTest (Left f, mempty)
+  catchAssertion g h = H.TestT $ E.catchE (H.unTest g) (H.unTest . h)
+
+instance MonadAssertion m => MonadAssertion (IO.ResourceT m) where
+  throwAssertion = lift . throwAssertion
+  catchAssertion r h = IO.ResourceT $ \i -> IO.unResourceT r i `catchAssertion` \e -> IO.unResourceT (h e) i
+
+deriving instance Monad m => MonadAssertion (H.PropertyT m)

--- a/hw-polysemy.cabal
+++ b/hw-polysemy.cabal
@@ -172,6 +172,7 @@ library hedgehog
                         process,
                         resourcet,
                         text,
+                        time,
                         transformers,
                         yaml,
   visibility:           public

--- a/hw-polysemy.cabal
+++ b/hw-polysemy.cabal
@@ -45,6 +45,7 @@ common tasty-hedgehog             { build-depends: tasty-hedgehog               
 common temporary                  { build-depends: temporary                                   < 1.4    }
 common text                       { build-depends: text                                        < 3      }
 common time                       { build-depends: time                                        < 2      }
+common transformers               { build-depends: transformers                                < 0.7    }
 common unliftio                   { build-depends: unliftio                                    < 0.3    }
 common yaml                       { build-depends: yaml                                        < 0.12   }
 
@@ -169,7 +170,9 @@ library hedgehog
                         polysemy-time,
                         polysemy,
                         process,
+                        resourcet,
                         text,
+                        transformers,
                         yaml,
   visibility:           public
   exposed-modules:      HaskellWorks.Polysemy.Hedgehog


### PR DESCRIPTION
* Add support to `Hedgehog` effect for the catching and throwing of assertions
* GHC.Real re-exports from `HaskellWorks.Prelude`
* New `byDeadlineM`, `byDeadlineIO`, `byDurationM` and `byDurationIO` functions