### PR TITLE
Fix callstack for AWS logs

### DIFF
--- a/hw-polysemy.cabal
+++ b/hw-polysemy.cabal
@@ -219,6 +219,7 @@ library amazonka
                         hw-polysemy-core,
                         lens,
                         polysemy-log,
+                        polysemy-time,
                         resourcet,
                         text,
                         stm,


### PR DESCRIPTION
Before the fix, the callsite that was annotated is the `log` function inside the interpreter which is not useful.

```
{
    "callstack": [
        {
            "caller": "log",
            "endCol": 17,
            "endLine": 133,
            "file": "amazonka/HaskellWorks/Polysemy/Amazonka.hs",
            "module": "HaskellWorks.Polysemy.Amazonka",
            "package": "hw-polysemy-0.2.14.5-l-amazonka-2ba1cc51bd2ca1323601337d15b4238b59b92fa12883f8efedda69dd17c53155",
            "startCol": 14,
            "startLine": 133
        }
    ],
    "data": {
        "message": "[ServiceError] {\n  service    = RDSData\n  status     = 400 Bad Request\n  code       = DatabaseError\n  message    = Just ERROR: relation \"no_such_object\" does not exist; Position: 22; SQLState: 42P01\n  request-id = Just 0a25ed83-0a01-4e54-8ed6-9671193e11f5\n}",
        "severity": "Error"
    },
    "time": "2024-09-21T13:08:27.595490158Z"
}
```

After the fix, the callsite that is annotated is the `sendAws` function that did the logging:

```
{
    "callstack": [
        {
            "caller": "sendAws",
            "endCol": 45,
            "endLine": 67,
            "file": "polysemy/Data/RdsData/Polysemy/Core.hs",
            "module": "Data.RdsData.Polysemy.Core",
            "package": "rds-data-0.0.0.7-inplace-polysemy",
            "startCol": 38,
            "startLine": 67
        }
    ],
    "data": {
        "message": "[ServiceError] {\n  service    = RDSData\n  status     = 400 Bad Request\n  code       = DatabaseError\n  message    = Just ERROR: relation \"no_such_object\" does not exist; Position: 22; SQLState: 42P01\n  request-id = Just ffefc4ae-10c2-472f-87f1-42876317cefc\n}",
        "severity": "Error"
    },
    "time": "2024-09-21T13:40:29.970512945Z"
}
```
