### PR TITLE
New `setLogLevelFromEnv` function

### DIFF
--- a/core/HaskellWorks/Polysemy/Log.hs
+++ b/core/HaskellWorks/Polysemy/Log.hs
@@ -17,21 +17,25 @@ module HaskellWorks.Polysemy.Log
 
     annotateCs,
     logCs,
+
+    setLogLevelFromEnv,
   ) where
 
 import           Data.Aeson
-import qualified Data.Aeson                  as J
-import qualified Data.ByteString.Lazy        as LBS
-import qualified Data.Text.Encoding          as T
+import qualified Data.Aeson                               as J
+import qualified Data.ByteString.Lazy                     as LBS
+import qualified Data.Text                                as T
+import qualified Data.Text.Encoding                       as T
 import           Data.Time
-import qualified GHC.Stack                   as GHC
+import qualified GHC.Stack                                as GHC
+import           HaskellWorks.Polysemy.System.Environment
 import           HaskellWorks.Prelude
 import           Polysemy
-import           Polysemy.Internal.Tactics   (liftT)
+import           Polysemy.Internal.Tactics                (liftT)
 import           Polysemy.Log
-import qualified Polysemy.Log.Effect.DataLog as Log
+import qualified Polysemy.Log.Effect.DataLog              as Log
 import           Polysemy.Time
-import qualified Polysemy.Time               as Time
+import qualified Polysemy.Time                            as Time
 
 interpretDataLogNoop :: forall a r. ()
   => InterpreterFor (DataLog a) r
@@ -109,3 +113,30 @@ logMessageToJson (LogMessage severity message) =
       [ "severity" .= show severity
       , "message"  .= message
       ]
+
+-- | Set the log level for the duration of the computation to the severity provided in the
+-- environment variable of the given name or else the default severity for the duration of
+-- the computation.
+--
+-- Values for the log level are case-insensitive and can be one of the following:
+--
+--   * trace
+--   * debug
+--   * info
+--   * warn
+--   * error
+--   * crit
+setLogLevelFromEnv :: ()
+  => HasCallStack
+  => Member (DataLog (LogEntry LogMessage)) r
+  => Member (Embed IO) r
+  => String
+  -> Severity
+  -> Sem r a
+  -> Sem r a
+setLogLevelFromEnv envVarName defaultSeverity f = do
+  maybeSeverityString <- lookupEnv envVarName
+
+  let maybeSeverity = maybeSeverityString >>= parseSeverity . T.pack
+
+  setLogLevel (maybeSeverity <|> Just defaultSeverity) f


### PR DESCRIPTION
With this, instead of:

```
   & setLogLevel (Just Info)
```

We can do this:

```
   & setLogLevelFromEnv "LOG_LEVEL" Info
```

This will allow the log level to be adjusted by environment variable and default to `Info` if the environment variable isn't defined.