### PR TITLE
Support for property testing

### DIFF
--- a/hedgehog/HaskellWorks/Polysemy/Hedgehog.hs
+++ b/hedgehog/HaskellWorks/Polysemy/Hedgehog.hs
@@ -27,6 +27,7 @@ module HaskellWorks.Polysemy.Hedgehog
     trapFailJsonPretty,
     trapFailYaml,
 
+    success,
     failure,
     failMessage,
     assert,
@@ -46,6 +47,7 @@ module HaskellWorks.Polysemy.Hedgehog
     evalIO_,
     evalM_,
 
+    classify,
     forAll,
 
     catchAssertion,

--- a/hedgehog/HaskellWorks/Polysemy/Hedgehog.hs
+++ b/hedgehog/HaskellWorks/Polysemy/Hedgehog.hs
@@ -29,6 +29,7 @@ module HaskellWorks.Polysemy.Hedgehog
 
     failure,
     failMessage,
+    assert,
     (===),
 
     byDeadlineIO,

--- a/hedgehog/HaskellWorks/Polysemy/Hedgehog.hs
+++ b/hedgehog/HaskellWorks/Polysemy/Hedgehog.hs
@@ -45,6 +45,8 @@ module HaskellWorks.Polysemy.Hedgehog
     evalIO_,
     evalM_,
 
+    forAll,
+
     catchAssertion,
     throwAssertion,
     trapAssertion,

--- a/hedgehog/HaskellWorks/Polysemy/Hedgehog.hs
+++ b/hedgehog/HaskellWorks/Polysemy/Hedgehog.hs
@@ -1,6 +1,7 @@
 
 module HaskellWorks.Polysemy.Hedgehog
-  ( propertyOnce,
+  ( property,
+    propertyOnce,
 
     Hedgehog,
 

--- a/hedgehog/HaskellWorks/Polysemy/Hedgehog/Effect/Hedgehog.hs
+++ b/hedgehog/HaskellWorks/Polysemy/Hedgehog/Effect/Hedgehog.hs
@@ -4,6 +4,7 @@
 module HaskellWorks.Polysemy.Hedgehog.Effect.Hedgehog
   ( Hedgehog,
 
+    assert,
     assertEquals,
     catchAssertion,
     eval,
@@ -38,6 +39,10 @@ import           Polysemy
 import           Polysemy.Final
 
 data Hedgehog m rv where
+  Assert :: HasCallStack
+    => Bool
+    -> Hedgehog m ()
+
   AssertEquals :: (HasCallStack, Eq a, Show a)
     => a
     -> a
@@ -97,6 +102,8 @@ hedgehogToMonadTestFinal :: forall a r m. ()
   => Sem (Hedgehog ': r) a
   -> Sem r a
 hedgehogToMonadTestFinal = interpretFinal \case
+  Assert t ->
+    liftS $ H.assert t
   AssertEquals a b ->
     liftS $ a H.=== b
   CatchAssertion f h -> do

--- a/hedgehog/HaskellWorks/Polysemy/Hedgehog/Effect/Hedgehog.hs
+++ b/hedgehog/HaskellWorks/Polysemy/Hedgehog/Effect/Hedgehog.hs
@@ -15,6 +15,8 @@ module HaskellWorks.Polysemy.Hedgehog.Effect.Hedgehog
     throwAssertion,
     trapAssertion,
 
+    forAll,
+
     hedgehogToMonadTestFinal,
     hedgehogToPropertyFinal,
     hedgehogToTestFinal,
@@ -138,3 +140,12 @@ catchExToPropertyFinal :: forall a r. ()
   -> Sem r a
 catchExToPropertyFinal = catchExToFinal
 {-# INLINE catchExToPropertyFinal #-}
+
+forAll :: forall a r. ()
+  => Member (Embed (H.PropertyT IO)) r
+  => Member Hedgehog r
+  => Show a
+  => H.Gen a
+  -> Sem r a
+forAll =
+  embed . H.forAll

--- a/hedgehog/HaskellWorks/Polysemy/Hedgehog/Effect/Hedgehog.hs
+++ b/hedgehog/HaskellWorks/Polysemy/Hedgehog/Effect/Hedgehog.hs
@@ -17,6 +17,8 @@ module HaskellWorks.Polysemy.Hedgehog.Effect.Hedgehog
     trapAssertion,
 
     forAll,
+    classify,
+    success,
 
     hedgehogToMonadTestFinal,
     hedgehogToPropertyFinal,
@@ -52,6 +54,11 @@ data Hedgehog m rv where
     => m a
     -> (H.Failure -> m a)
     -> Hedgehog m a
+
+  Classify ::  HasCallStack
+    => H.LabelName
+    -> Bool
+    -> Hedgehog m ()
 
   Eval :: HasCallStack
     => a
@@ -112,6 +119,8 @@ hedgehogToMonadTestFinal = interpretFinal \case
     h' <- bindS h
     pure $ I.catchAssertion f' $ \e -> do
       h' (e <$ s)
+  Classify labelName b ->
+    liftS $ H.classify labelName b
   Eval a ->
     liftS $ H.eval a
   EvalIO f ->
@@ -156,3 +165,9 @@ forAll :: forall a r. ()
   -> Sem r a
 forAll =
   embed . H.forAll
+
+success :: forall r. ()
+  => Member Hedgehog r
+  => Sem r ()
+success =
+  pure ()

--- a/hedgehog/HaskellWorks/Polysemy/Hedgehog/Gen.hs
+++ b/hedgehog/HaskellWorks/Polysemy/Hedgehog/Gen.hs
@@ -1,0 +1,5 @@
+module HaskellWorks.Polysemy.Hedgehog.Gen
+  ( module G
+  ) where
+
+import           Hedgehog.Gen as G

--- a/hedgehog/HaskellWorks/Polysemy/Hedgehog/Range.hs
+++ b/hedgehog/HaskellWorks/Polysemy/Hedgehog/Range.hs
@@ -1,0 +1,5 @@
+module HaskellWorks.Polysemy.Hedgehog.Range
+  ( module R
+  ) where
+
+import           Hedgehog.Range as R

--- a/hw-polysemy.cabal
+++ b/hw-polysemy.cabal
@@ -201,11 +201,13 @@ library hedgehog
                         HaskellWorks.Polysemy.Hedgehog.Effect.Hedgehog.Internal
                         HaskellWorks.Polysemy.Hedgehog.Effect.Log
                         HaskellWorks.Polysemy.Hedgehog.Eval
+                        HaskellWorks.Polysemy.Hedgehog.Gen
                         HaskellWorks.Polysemy.Hedgehog.Golden
                         HaskellWorks.Polysemy.Hedgehog.Jot
                         HaskellWorks.Polysemy.Hedgehog.Process
                         HaskellWorks.Polysemy.Hedgehog.Process.Internal
                         HaskellWorks.Polysemy.Hedgehog.Property
+                        HaskellWorks.Polysemy.Hedgehog.Range
                         HaskellWorks.Polysemy.Hedgehog.Test
                         HaskellWorks.Polysemy.Hedgehog.Time
                         HaskellWorks.Polysemy.Hedgehog.Ulid
@@ -289,11 +291,13 @@ library
                         HaskellWorks.Polysemy.Hedgehog.Effect.Hedgehog.Internal,
                         HaskellWorks.Polysemy.Hedgehog.Effect.Log,
                         HaskellWorks.Polysemy.Hedgehog.Eval,
+                        HaskellWorks.Polysemy.Hedgehog.Gen,
                         HaskellWorks.Polysemy.Hedgehog.Golden,
                         HaskellWorks.Polysemy.Hedgehog.Jot,
                         HaskellWorks.Polysemy.Hedgehog.Process,
                         HaskellWorks.Polysemy.Hedgehog.Process.Internal,
                         HaskellWorks.Polysemy.Hedgehog.Property,
+                        HaskellWorks.Polysemy.Hedgehog.Range,
                         HaskellWorks.Polysemy.Hedgehog.Test,
                         HaskellWorks.Polysemy.Hedgehog.Workspace,
                         HaskellWorks.Polysemy.Prelude,


### PR DESCRIPTION
Previously it was not possibly to property test with the `Hedgehog` effect because the library did not provide the `forAll` function.